### PR TITLE
Add missing dispose statements in CloudWatch docs

### DIFF
--- a/doc_source/how-to/cloudwatch/cloudwatch-creating-alarms-examples.rst
+++ b/doc_source/how-to/cloudwatch/cloudwatch-creating-alarms-examples.rst
@@ -68,14 +68,14 @@ method of the ``AmazonCloudWatchClient`` object.
 
 .. code-block:: c#
 
-        using (var cloudWatch = new AmazonCloudWatchClient(RegionEndpoint.USWest2))
+        using (var client = new AmazonCloudWatchClient(RegionEndpoint.USWest2))
         {
             var request = new DescribeAlarmsRequest();
             request.StateValue = "INSUFFICIENT_DATA";
             request.AlarmNames = new List<string> { "Alarm1", "Alarm2" };
             do
             {
-                var response = cloudWatch.DescribeAlarms(request);
+                var response = client.DescribeAlarms(request);
                 foreach(var alarm in response.MetricAlarms)
                 {
                     Console.WriteLine(alarm.AlarmName);
@@ -100,28 +100,30 @@ method of the ``AmazonCloudWatchClient`` object.
 
 .. code-block:: C#
 
-            var client = new AmazonCloudWatchClient(RegionEndpoint.USWest2);
-            client.PutMetricAlarm(
-                new PutMetricAlarmRequest
-                {
-                    AlarmName = "Web_Server_CPU_Utilization",
-                    ComparisonOperator = ComparisonOperator.GreaterThanThreshold,
-                    EvaluationPeriods = 1,
-                    MetricName = "CPUUtilization",
-                    Namespace = "AWS/EC2",
-                    Period = 60,
-                    Statistic = Statistic.Average,
-                    Threshold = 70.0,
-                    ActionsEnabled = true,
-                    AlarmActions = new List<string> { "arn:aws:swf:us-west-2:" + "customerAccount" + ":action/actions/AWS_EC2.InstanceId.Reboot/1.0" },
-                    AlarmDescription = "Alarm when server CPU exceeds 70%",
-                    Dimensions = new List<Dimension>
-                        {
-                            new Dimension { Name = "InstanceId", Value = "INSTANCE_ID" }
-                        },
-                    Unit = StandardUnit.Seconds
-                } 
-            );
+            using (var client = new AmazonCloudWatchClient(RegionEndpoint.USWest2))
+            {
+                client.PutMetricAlarm(
+                    new PutMetricAlarmRequest
+                    {
+                        AlarmName = "Web_Server_CPU_Utilization",
+                        ComparisonOperator = ComparisonOperator.GreaterThanThreshold,
+                        EvaluationPeriods = 1,
+                        MetricName = "CPUUtilization",
+                        Namespace = "AWS/EC2",
+                        Period = 60,
+                        Statistic = Statistic.Average,
+                        Threshold = 70.0,
+                        ActionsEnabled = true,
+                        AlarmActions = new List<string> { "arn:aws:swf:us-west-2:" + "customerAccount" + ":action/actions/AWS_EC2.InstanceId.Reboot/1.0" },
+                        AlarmDescription = "Alarm when server CPU exceeds 70%",
+                        Dimensions = new List<Dimension>
+                            {
+                                new Dimension { Name = "InstanceId", Value = "INSTANCE_ID" }
+                            },
+                        Unit = StandardUnit.Seconds
+                    } 
+                );
+            }
 
 .. _cloudwatch-example-deleting-alarms:
 
@@ -135,9 +137,9 @@ method of the ``AmazonCloudWatchClient`` object.
 
 .. code-block:: c#
 
-            using (var cloudWatch = new AmazonCloudWatchClient(RegionEndpoint.USWest2))
+            using (var client = new AmazonCloudWatchClient(RegionEndpoint.USWest2))
             {
-                var response = cloudWatch.DeleteAlarms(
+                var response = client.DeleteAlarms(
                     new DeleteAlarmsRequest
                     {
                         AlarmNames = new List<string> { "Alarm1", "Alarm2" };

--- a/doc_source/how-to/cloudwatch/cloudwatch-examples-sending-events.rst
+++ b/doc_source/how-to/cloudwatch/cloudwatch-examples-sending-events.rst
@@ -67,52 +67,53 @@ CWEvents, setting it's trust relationship and role policy.
 
         static void Main()
         {
-            var client = new AmazonIdentityManagementServiceClient();
-            // Create a role and it's trust relationship policy
-            var role = client.CreateRole(new CreateRoleRequest
+            using (var client = new AmazonIdentityManagementServiceClient())
             {
-                RoleName = "CWEvents",
-                AssumeRolePolicyDocument = 
-                @"{""Statement"":[{""Principal"":{""Service"":[""events.amazonaws.com""]}," + 
-                @"""Effect"":""Allow"",""Action"":[""sts:AssumeRole""]}]}"
-            }).Role;
-            // Create a role policy and add it to the role
-            string policy = GenerateRolePolicyDocument();
-            var request = new CreatePolicyRequest
-            {
-                PolicyName = "DemoCWPermissions",
-                PolicyDocument = policy
-            };
-            try
-            {
-                var createPolicyResponse = client.CreatePolicy(request);
+                // Create a role and it's trust relationship policy
+                var role = client.CreateRole(new CreateRoleRequest
+                {
+                    RoleName = "CWEvents",
+                    AssumeRolePolicyDocument = 
+                    @"{""Statement"":[{""Principal"":{""Service"":[""events.amazonaws.com""]}," + 
+                    @"""Effect"":""Allow"",""Action"":[""sts:AssumeRole""]}]}"
+                }).Role;
+                // Create a role policy and add it to the role
+                string policy = GenerateRolePolicyDocument();
+                var request = new CreatePolicyRequest
+                {
+                    PolicyName = "DemoCWPermissions",
+                    PolicyDocument = policy
+                };
+                try
+                {
+                    var createPolicyResponse = client.CreatePolicy(request);
+                }
+                catch (EntityAlreadyExistsException)
+                {
+                    Console.WriteLine
+                    ("Policy 'DemoCWPermissions' already exits.");
+                }
+                var request2 = new AttachRolePolicyRequest()
+                {
+                    PolicyArn = "arn:aws:iam::192484417122:policy/DemoCWPermissions",
+                    RoleName = "CWEvents"
+                };
+                try
+                {
+                    var response = client.AttachRolePolicy(request2);    //managedpolicy
+                    Console.WriteLine("Policy DemoCWPermissions attached to Role TestUser");
+                }
+                catch (NoSuchEntityException)
+                {
+                    Console.WriteLine
+                    ("Policy 'DemoCWPermissions' does not exist");
+                }
+                catch (InvalidInputException)
+                {
+                    Console.WriteLine
+                    ("One of the parameters is incorrect");
+                }
             }
-            catch (EntityAlreadyExistsException)
-            {
-                Console.WriteLine
-                  ("Policy 'DemoCWPermissions' already exits.");
-            }
-            var request2 = new AttachRolePolicyRequest()
-            {
-                PolicyArn = "arn:aws:iam::192484417122:policy/DemoCWPermissions",
-                RoleName = "CWEvents"
-            };
-            try
-            {
-                var response = client.AttachRolePolicy(request2);    //managedpolicy
-                Console.WriteLine("Policy DemoCWPermissions attached to Role TestUser");
-            }
-            catch (NoSuchEntityException)
-            {
-                Console.WriteLine
-                  ("Policy 'DemoCWPermissions' does not exist");
-            }
-            catch (InvalidInputException)
-            {
-                Console.WriteLine
-                  ("One of the parameters is incorrect");
-            }
-
         }
         public static string GenerateRolePolicyDocument()
         {
@@ -190,8 +191,7 @@ returns the ARN of the new or updated rule.
 
 .. code-block:: c#
 
-            AmazonCloudWatchEventsClient client = new AmazonCloudWatchEventsClient();
-
+            
             var putRuleRequest = new PutRuleRequest
             {
                 Name = "DEMO_EVENT",
@@ -200,8 +200,11 @@ returns the ARN of the new or updated rule.
                 State = RuleState.ENABLED
             };
 
-            var putRuleResponse = client.PutRule(putRuleRequest);
-            Console.WriteLine("Successfully set the rule {0}", putRuleResponse.RuleArn);
+            using (var client = new AmazonCloudWatchEventsClient())
+            {
+                var putRuleResponse = client.PutRule(putRuleRequest);
+                Console.WriteLine("Successfully set the rule {0}", putRuleResponse.RuleArn);
+            }
 
 Add a |LAM| Function Target
 ============================
@@ -214,8 +217,7 @@ method of the :code:`AmazonCloudWatchClient` instance.
 
 .. code-block:: c#
 
-            AmazonCloudWatchEventsClient client = new AmazonCloudWatchEventsClient();
-
+            
             var putTargetRequest = new PutTargetsRequest
             {
                 Rule = "DEMO_EVENT",
@@ -224,7 +226,10 @@ method of the :code:`AmazonCloudWatchClient` instance.
                     new Target { Arn = "LAMBDA_FUNCTION_ARN", Id = "myCloudWatchEventsTarget"}
                 }
             };
-            client.PutTargets(putTargetRequest);
+            using (var client = new AmazonCloudWatchEventsClient())
+            {
+                client.PutTargets(putTargetRequest);
+            }
 
 
 Send Events
@@ -238,9 +243,6 @@ the ARNs of any resources affected by the event, and details for the event. Call
 method of the :code:`AmazonCloudWatchClient` instance.
 
 .. code-block:: c#
-
-
-            AmazonCloudWatchEventsClient client = new AmazonCloudWatchEventsClient();
 
             var putEventsRequest = new PutEventsRequest
             {
@@ -258,4 +260,7 @@ method of the :code:`AmazonCloudWatchClient` instance.
                     }
                 }
             };
-            client.PutEvents(putEventsRequest);
+            using (var client = new AmazonCloudWatchEventsClient())
+            {
+                client.PutEvents(putEventsRequest);
+            }

--- a/doc_source/how-to/cloudwatch/cloudwatch-getting-metrics-examples.rst
+++ b/doc_source/how-to/cloudwatch/cloudwatch-getting-metrics-examples.rst
@@ -70,9 +70,9 @@ a :sdk-net-api:`AmazonCloudWatchClient <CloudWatch/TCloudWatchCloudWatchClient>`
             Name = "UniquePages",
             Value = "URLs"
         };
-        using (var cw = new AmazonCloudWatchClient(RegionEndpoint.USWest2))
+        using (var client = new AmazonCloudWatchClient(RegionEndpoint.USWest2))
         {
-            var listMetricsResponse = cw.ListMetrics(new ListMetricsRequest
+            var listMetricsResponse = client.ListMetrics(new ListMetricsRequest
             {
                 Dimensions = dimensionFilterList,
                 MetricName = "IncomingLogEvents",
@@ -92,9 +92,9 @@ from the :sdk-net-api:`AmazonCloudWatchClient <CloudWatch/TCloudWatchCloudWatchC
 
 .. code-block:: c#
 
-        using (var cw = new AmazonCloudWatchClient(RegionEndpoint.USWest2))
+        using (var client = new AmazonCloudWatchClient(RegionEndpoint.USWest2))
         {
-            cw.PutMetricData(new PutMetricDataRequest
+            client.PutMetricData(new PutMetricDataRequest
             {
                 MetricData = new List<MetricDatum>{new MetricDatum
                 {

--- a/doc_source/how-to/cloudwatch/cloudwatch-using-subscriptions-examples.rst
+++ b/doc_source/how-to/cloudwatch/cloudwatch-using-subscriptions-examples.rst
@@ -68,19 +68,25 @@ method.
 
         public static void DescribeSubscriptionFilters()
         {
-            var client = new AmazonCloudWatchLogsClient();
             var request = new Amazon.CloudWatchLogs.Model.DescribeSubscriptionFiltersRequest()
             {
                 LogGroupName = "GROUP_NAME",
                 Limit = 5
             };
+
+            AmazonCloudWatchLogsClient client = null;
             try
             {
+                client = new AmazonCloudWatchLogsClient();
                 var response = client.DescribeSubscriptionFilters(request);
             }
             catch (Amazon.CloudWatchLogs.Model.ResourceNotFoundException e)
             {
                 Console.WriteLine(e.Message);
+            } 
+            finally 
+            {
+                client?.Dispose();
             }
         }
 
@@ -98,7 +104,6 @@ method.
 
         public static void PutSubscriptionFilters()
         {
-            var client = new AmazonCloudWatchLogsClient();
             var request = new Amazon.CloudWatchLogs.Model.PutSubscriptionFilterRequest()
             {
                 DestinationArn = "LAMBDA_FUNCTION_ARN",
@@ -106,13 +111,20 @@ method.
                 FilterPattern = "ERROR",
                 LogGroupName = "Log_Group"
             };
+
+            AmazonCloudWatchLogsClient client = null;
             try
             {
+                client = var AmazonCloudWatchLogsClient();
                 var response = client.PutSubscriptionFilter(request);
             }
             catch (InvalidParameterException e)
             {
                 Console.WriteLine(e.Message);
+            }
+            finally
+            {
+                client?.Dispose();
             }
         }
 
@@ -129,18 +141,24 @@ method.
 
         public static void DeleteSubscriptionFilter()
         {
-            var client = new AmazonCloudWatchLogsClient();
             var request = new Amazon.CloudWatchLogs.Model.DeleteSubscriptionFilterRequest()
             {
                 LogGroupName = "GROUP_NAME",
                 FilterName = "FILTER"
             };
+
+            AmazonCloudWatchLogsClient client = null;
             try
             {
+                client = new AmazonCloudWatchLogsClient();
                 var response = client.DeleteSubscriptionFilter(request);
             }
             catch (Amazon.CloudWatchLogs.Model.ResourceNotFoundException e)
             {
                 Console.WriteLine(e.Message);
+            }
+            finally
+            {
+                client?.Dispose();
             }
         }


### PR DESCRIPTION
*Description of changes:*
I spotted some missing `using` statements while browsing the CloudWatch docs, so I thought I should add them. I tried to improve consistency between examples as well by renaming some variables.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
