### PR TITLE
Configuring aws sdk for net typo fix

### DIFF
--- a/doc_source/net-dg-config-netcore.rst
+++ b/doc_source/net-dg-config-netcore.rst
@@ -74,7 +74,7 @@ Allowed Values in appsettings File
 
 The following app configuration values can be set in the :file:`appsettings.Development.json` file. 
 The field names must use the casing shown in the list below. For details on these settings, refer to 
-the :sdk-net-api:`AWS.Runtime.ClientConfg <Runtime/TRuntimeClientConfig>` class.
+the :sdk-net-api:`AWS.Runtime.ClientConfg <Runtime/TClientConfig>` class.
 
 * Region
 * Profile


### PR DESCRIPTION
Issue #27 

Fix typo on AWS.Runtime.ClientConfig API reference link

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.