### PR TITLE
Ignoring shared content from source fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 README.html
 output/
+shared_content/


### PR DESCRIPTION
Adding `shared_content/` folder in .gitignore file to avoid wrong check-ins. Also ignoring it as it's not part of the source. Please, feel free to accept or reject the suggestion.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.