### PR TITLE
Added AWS_PROFILE option to .NET configs

### DIFF
--- a/doc_source/net-dg-config-creds.rst
+++ b/doc_source/net-dg-config-creds.rst
@@ -188,6 +188,31 @@ Use can manage the profiles in the shared credentials file in two ways:
 
 * You can programmatically manage the credentials file by using the classes in the :sdk-net-api:`Amazon.Runtime.CredentialManagement <Runtime/NRuntimeCredentialManagement>` namespace.
 
+Setting an Alternate Credentials Profile
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+      The |sdk-net| uses the `default` profile by default, but there are ways to customize
+      which profile is sourced from the credentials file.
+
+      You can use the AWS Profile environment variable to change the profile loaded by the SDK.
+
+      For example, on |unixes| you would run the following command to change the profile to `myProfile`.
+
+      .. code-block:: sh
+
+          export AWS_PROFILE="myProfile"
+
+      On Windows you would use the following.
+
+      .. code-block:: bat
+
+          set AWS_PROFILE="myProfile"
+
+      Setting the AWS_PROFILE environment variable affects credential loading for all officially
+      supported AWS SDKs and Tools (including the AWS CLI and the AWS CLI for PowerShell).
+
+      .. note:: The environment variable takes precedence over the system property.
+
 Create a Profile and Save it to the Shared Credentials File
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Added AWS_PROFILE option to .NET configs

*Description of changes:*
Per https://aws.amazon.com/blogs/developer/using-the-aws_profile-environment-variable-to-choose-a-profile/, the AWS_PROFILE environment variable is honored in .NET, but the docs don't have any references to it.

I took the language from the Java docs (https://github.com/awsdocs/aws-java-developer-guide/blob/master/doc_source/credentials.rst) and modified it a bit to match .NET.

