### PR TITLE
Remove incorrect dedent from cognito-authentication-extension.rst

### DIFF
--- a/doc_source/cognito-authentication-extension.rst
+++ b/doc_source/cognito-authentication-extension.rst
@@ -32,7 +32,7 @@ The following examples require these :code:`using` statements:
 
 .. literalinclude:: samples/cognito-extensions.cs
    :lines: 1-10
-   :dedent: 8
+   :dedent: 0
    :language: csharp
 
 Use Basic Authentication


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The list of `using` statements shown is missing the first 8 characters of each line. I think this is because the `dedent` parameter has been set incorrectly, so I have changed it to be the correct value of 0.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
