### PR TITLE
Remove quotes when setting AWS_PROFILE env var on Windows

### DIFF
--- a/doc_source/net-dg-config-creds.rst
+++ b/doc_source/net-dg-config-creds.rst
@@ -203,7 +203,7 @@ On Windows use the following command.
 
 .. code-block:: bat
 
-    set AWS_PROFILE="myProfile"
+    set AWS_PROFILE=myProfile
 
 Setting the **AWS_PROFILE** environment variable affects credential loading for all officially
 supported AWS SDKs and Tools, including the AWS CLI and the AWS CLI for PowerShell.


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Correcting syntax for setting the `AWS_PROFILE` environment variable on Windows.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
