### PR TITLE
No such thing as "IAM Account" only "IAM Alias"

### DIFF
--- a/doc_source/iam-examples-account-aliases.md
+++ b/doc_source/iam-examples-account-aliases.md
@@ -1,4 +1,4 @@
-# Managing IAM Account Aliases<a name="iam-examples-account-aliases"></a>
+# Managing IAM Aliases<a name="iam-examples-account-aliases"></a>
 
 These \.NET examples show you how to:
 + Create an account alias for your AWS account ID


### PR DESCRIPTION
*Issue #, if available:*  Clarification about the term: "IAM Account"

*Description of changes:*

An AWS account can have an IAM Alias. But there is no such thing as an "IAM Account" in AWS. Hence, the title of this article should use "IAM Alias" instead, and be renamed as "Managing IAM Aliases". 

If you use "IAM Account", then people will wrongly think that there is a different "IAM" account for the IAM service, and another one for the actual AWS account.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
